### PR TITLE
fix(cli): only print citation if flag is set

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools
           pip install .[dev,test]
+      - name: Check CLI flags
+        run: |
+          tool_name --help
+          tool_name --version
+          tool_name --citation
       - name: Test stub run
         run: |
           tool_name run -profile ci_stub,docker -stub

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -36,6 +36,7 @@ def common_options(func):
     is_flag=True,
     callback=print_citation,
     expose_value=False,
+    is_eager=True,
     help="Print the citation in bibtex format and exit.",
 )
 def cli():

--- a/src/util.py
+++ b/src/util.py
@@ -25,6 +25,8 @@ def get_version():
 
 
 def print_citation(context, param, value):
+    if not value or context.resilient_parsing:
+        return
     citation = create_citation(nek_base("CITATION.cff"), None)
     # click.echo(citation._implementation.cffobj['message'])
     validate_or_write_output(None, "bibtex", False, citation)


### PR DESCRIPTION
## Changes

Details on resilient parsing and eager options in click: https://click.palletsprojects.com/en/8.1.x/options/\#callbacks-and-eager-options

Propagate fix to nextflow pipelines:

- [CHAMPAGNE](https://github.com/CCBR/CHAMPAGNE/commit/97eb275bbbb56549debe08e281e715b25c76bf17)
- [CRUISE](https://github.com/CCBR/CRUISE/commit/eab7399d65591881f4b49d02842f362467bafc28)
- [LOGAN](https://github.com/CCBR/LOGAN/commit/cbf9b8f1865b426f1044ce486242ab42882f3656)
- [SINCLAIR](https://github.com/CCBR/SINCLAIR/commit/8d6d40c6d3b4d9faaa7d8ba576a63b8060c253d0)

## Issues

fixes #21

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~ _testing framework not yet implemented_
- ~[ ] Update docs if there are any API changes.~ _on hold until before public release_
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- ~[ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/~
