### PR TITLE
docs: hide --main and show nextflow options in help

### DIFF
--- a/.github/workflows/build-nextflow.yml
+++ b/.github/workflows/build-nextflow.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           mkdir -p tmp && pushd tmp
           tool_name init
-          tool_name run -c conf/ci_stub.config -stub
+          tool_name run -c conf/ci_stub.config -stub --mode local
           popd
       - name: "Upload Artifact"
         uses: actions/upload-artifact@v4

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -67,12 +67,12 @@ Nextflow options:
 \b
 EXAMPLES:
 Execute with slurm:
-  tool_name run ... --mode slurm
+  tool_name run --output path/to/outdir --mode slurm
 Preview the processes that will run:
-  tool_name run ... --mode local -preview
+  tool_name run --output path/to/outdir --mode local -preview
 Add nextflow args (anything supported by `nextflow run`):
-  tool_name run ... --mode slurm -profile test
-  tool_name run ... --mode slurm -profile test -params-file assets/params.yml
+  tool_name run --output path/to/outdir --mode slurm -profile test
+  tool_name run --output path/to/outdir --mode slurm -profile test -params-file assets/params.yml
 """
 
 
@@ -103,7 +103,7 @@ Add nextflow args (anything supported by `nextflow run`):
     "_mode",
     help="Run mode (slurm, local)",
     type=str,
-    default="local",
+    default="slurm",
     show_default=True,
 )
 @click.option(

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -59,17 +59,20 @@ def cli():
 
 help_msg_extra = """
 \b
+Nextflow options:
+-profile <profile>    Nextflow profile to use (e.g. test)
+-params-file <file>   Nextflow params file to use (e.g. assets/params.yml)
+-preview              Preview the processes that will run without executing them
+
+\b
 EXAMPLES:
 Execute with slurm:
-    tool_name run ... --mode slurm
+  tool_name run ... --mode slurm
 Preview the processes that will run:
-    tool_name run ... --mode local -preview
+  tool_name run ... --mode local -preview
 Add nextflow args (anything supported by `nextflow run`):
-    tool_name run ... -work-dir path/to/workDir
-Run with a specific installation of tool_name:
-    tool_name run --main path/to/tool_name/main.nf ...
-Run with a specific tag, branch, or commit from GitHub:
-    tool_name run --main CCBR/TOOL_NAME -r v0.1.0 ...
+  tool_name run ... --mode slurm -profile test
+  tool_name run ... --mode slurm -profile test -params-file assets/params.yml
 """
 
 
@@ -86,6 +89,7 @@ Run with a specific tag, branch, or commit from GitHub:
     type=str,
     default=repo_base("main.nf"),
     show_default=True,
+    hidden=True,
 )
 @click.option(
     "--output",
@@ -115,6 +119,9 @@ Run with a specific tag, branch, or commit from GitHub:
 def run(main_path, output, _mode, force_all, **kwargs):
     """
     Run the workflow
+
+    Note: you must first run `tool_name init --output <output_dir>` to initialize
+    the output directory.
 
     docs: https://ccbr.github.io/TOOL_NAME
     """


### PR DESCRIPTION
## Changes

- set `--main` to hidden
- add nextflow options to help message
- clarify that `init` must be run before `run`
- `--mode` default is now `slurm`

## Issues

fixes #49

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~
- [x] Update docs if there are any API changes.
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- ~[ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/~